### PR TITLE
Added certificate thumbprint to logging

### DIFF
--- a/ServiceFabricGateway/Gateway/ApplicationInsightsTelemetryLogger.cs
+++ b/ServiceFabricGateway/Gateway/ApplicationInsightsTelemetryLogger.cs
@@ -32,6 +32,12 @@ namespace Gateway
             this.requestTelemetry.Name = $"{request.Method.ToString().ToUpper()} {request.RequestUri}";
             this.requestTelemetry.Timestamp = startDate;
             this.requestTelemetry.Url = request.RequestUri;
+
+            var certificate = request.GetClientCertificate();
+            if (certificate != null)
+            {
+                this.requestTelemetry.Properties.Add("ClientCertificateThumbprint", certificate.Thumbprint);
+            }
         }
 
         private void TrackRequest(HttpStatusCode responseStatus, TimeSpan duration)


### PR DESCRIPTION
This is so we can diagnose issues when a certificate is attached in the request but is not passed through to the service fabric applications